### PR TITLE
Get commit hash directly with git if git_sha modul does not exist

### DIFF
--- a/heartbeat/heartbeat.py
+++ b/heartbeat/heartbeat.py
@@ -27,10 +27,7 @@ class HeartbeatRequestHandler(BaseHTTPRequestHandler):
                 import git_sha
                 commit_hash = git_sha.git_sha
             except ImportError:
-                try:
-                    commit_hash = subprocess.check_output(["git", "rev-parse", "HEAD"])
-                except subprocess.CalledProcessError:
-                    commit_hash = 'NA'
+                commit_hash = subprocess.check_output(["git", "rev-parse", "HEAD"])
 
             obj = {'status': 'running', 'build': commit_hash.strip(), 'uptime': uptime}
             self.wfile.write(('\n' + json.dumps(obj) + "\n").encode('utf-8'))

--- a/heartbeat/heartbeat.py
+++ b/heartbeat/heartbeat.py
@@ -1,40 +1,49 @@
 import sys
-
-if sys.version > '3':
-  from http.server import HTTPServer
-  from http.server import BaseHTTPRequestHandler
-else:
-  from BaseHTTPServer import HTTPServer
-  from BaseHTTPServer import BaseHTTPRequestHandler
-
 import json
 import threading
 import datetime
+import subprocess
 
-import git_sha
+if sys.version > '3':
+    from http.server import HTTPServer
+    from http.server import BaseHTTPRequestHandler
+else:
+    from BaseHTTPServer import HTTPServer
+    from BaseHTTPServer import BaseHTTPRequestHandler
 
 global starting_time
 starting_time = None
 
+
 class HeartbeatRequestHandler(BaseHTTPRequestHandler):
-  def do_GET(self) :
-    global starting_time
-    if self.path == '/heartbeat' :
-      self.send_response(200)
-      self.send_header('Content-type:', 'text/html')
-      now = datetime.datetime.now()
-      uptime = str(now - starting_time)
-      obj = {'status': 'running', 'build': git_sha.git_sha, 'uptime': uptime}
-      self.wfile.write(('\n' + json.dumps(obj) + "\n").encode('utf-8'))
+    def do_GET(self):
+        global starting_time
+        if self.path == '/heartbeat':
+            self.send_response(200)
+            self.send_header('Content-type:', 'text/html')
+            now = datetime.datetime.now()
+            uptime = str(now - starting_time)
+            try:
+                import git_sha
+                commit_hash = git_sha.git_sha
+            except ImportError:
+                try:
+                    commit_hash = subprocess.check_output(["git", "rev-parse", "HEAD"])
+                except subprocess.CalledProcessError:
+                    commit_hash = 'NA'
+
+            obj = {'status': 'running', 'build': commit_hash.strip(), 'uptime': uptime}
+            self.wfile.write(('\n' + json.dumps(obj) + "\n").encode('utf-8'))
+
 
 def run_heartbeat_service(port, addr=''):
-  global starting_time
-  starting_time = datetime.datetime.now()
-  class HeartbeatServer(threading.Thread):
-    def run(self):
-      httpd = HTTPServer((addr, port), HeartbeatRequestHandler)
-      httpd.serve_forever()
-  t = HeartbeatServer()
-  t.daemon = True
-  t.start()
+    global starting_time
+    starting_time = datetime.datetime.now()
 
+    class HeartbeatServer(threading.Thread):
+        def run(self):
+            httpd = HTTPServer((addr, port), HeartbeatRequestHandler)
+            httpd.serve_forever()
+    t = HeartbeatServer()
+    t.daemon = True
+    t.start()


### PR DESCRIPTION
# What is this PR?

Heartbeat module expect a `git_sha` python module which contains the git commit hash. This file has to be generated outside of this project and could be painful in case of remote deployment and instant local development.
# Solution

Get commit hash if `git_sha` module does not exist.
# Additional changes:
- pep8ify source code
