### PR TITLE
Call git rev-parse from the project dir

### DIFF
--- a/heartbeat/heartbeat.py
+++ b/heartbeat/heartbeat.py
@@ -3,6 +3,7 @@ import json
 import threading
 import datetime
 import subprocess
+import os
 
 if sys.version > '3':
     from http.server import HTTPServer
@@ -27,7 +28,11 @@ class HeartbeatRequestHandler(BaseHTTPRequestHandler):
                 import git_sha
                 commit_hash = git_sha.git_sha
             except ImportError:
-                commit_hash = subprocess.check_output(["git", "rev-parse", "HEAD"])
+                p = subprocess.Popen(["git", "rev-parse", "HEAD"],
+                                     stdout=subprocess.PIPE,
+                                     cwd=os.path.dirname(os.path.realpath(__file__)))
+                p.wait()
+                commit_hash = p.stdout.read().strip()
 
             obj = {'status': 'running', 'build': commit_hash.strip(), 'uptime': uptime}
             self.wfile.write(('\n' + json.dumps(obj) + "\n").encode('utf-8'))

--- a/heartbeat/heartbeat.py
+++ b/heartbeat/heartbeat.py
@@ -28,11 +28,8 @@ class HeartbeatRequestHandler(BaseHTTPRequestHandler):
                 import git_sha
                 commit_hash = git_sha.git_sha
             except ImportError:
-                p = subprocess.Popen(["git", "rev-parse", "HEAD"],
-                                     stdout=subprocess.PIPE,
-                                     cwd=os.path.dirname(os.path.realpath(__file__)))
-                p.wait()
-                commit_hash = p.stdout.read().strip()
+                commit_hash = subprocess.check_output(["git", "rev-parse", "HEAD"],
+                                                      cwd=os.path.dirname(os.path.realpath(__file__))).strip()
 
             obj = {'status': 'running', 'build': commit_hash.strip(), 'uptime': uptime}
             self.wfile.write(('\n' + json.dumps(obj) + "\n").encode('utf-8'))


### PR DESCRIPTION
Git rev-parse fetching was called from random working directories which caused errors. This patch fixes it by explicitly setting CWD to the git shell call.
